### PR TITLE
Use curl to determine external IP in setup

### DIFF
--- a/set-host.sh
+++ b/set-host.sh
@@ -1,5 +1,5 @@
 # VON Agent host name on play-with-docker, 
 # e.g. ssh ip172-18-0-16-bg5dvdk3uhdg00cihaa0@direct.labs.play-with-docker.com
 #      --> ip172-18-0-16-bg5dvdk3uhdg00cihaa0-5001.direct.labs.play-with-docker.com
-export ENDPOINT_HOST=<your play-with-docker host name>
+export ENDPOINT_HOST=`curl https://ipinfo.io/ip`
 


### PR DESCRIPTION
Update setup script to automatically determine external IP address used by docker playground container.