### PR TITLE
Fix config to run on local docker instance.

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -85,7 +85,7 @@ configureEnvironment () {
   export COMPOSE_PROJECT_NAME=myorg
   export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-"myorg"}
   export LEDGER_URL=${LEDGER_URL-http://$DOCKERHOST:9000}
-  export APPLICATION_URL=${APPLICATION_URL-http://10.10.10.246:${WEB_HTTP_PORT:-5000}}
+  export APPLICATION_URL=${APPLICATION_URL-http://localhost:${WEB_HTTP_PORT:-5000}}
   export ENDPOINT_URL=http://${ENDPOINT_HOST-$DOCKERHOST:${WEB_HTTP_PORT:-5001}}
 
   # wallet-db

--- a/von-x-agent/config/services.yml
+++ b/von-x-agent/config/services.yml
@@ -33,7 +33,7 @@ issuers:
     credential_types:
     - description: Permit
       schema: my-permit.my-organization
-      issuer_url: $ENDPOINT_URL/my-organization/my-permit
+      issuer_url: $APPLICATION_URL/my-organization/my-permit
       depends_on:
         - dflow_registration
       credential:


### PR DESCRIPTION
The changes align the configuration to what is used in dFlow for running the project against a local Docker instance.

In particular:
- the `APPLICATION_URL` was set to default to a hard-coded IP address, rather than localhost.
- the `issuer url` in `services.yml` was using the `ENDPOINT_URL` rather than the `APPLICATION_URL`. This caused it to point to the `DOCKERHOST` IP address, which is apparently not resolvable from the host machine.